### PR TITLE
Update ecc-jsbn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsbn": "~0.1.0",
     "tweetnacl": "~0.13.0",
     "jodid25519": "^1.0.0",
-    "ecc-jsbn": "~0.0.1"
+    "ecc-jsbn": "~0.1.1"
   },
   "devDependencies": {
     "tape": "^3.5.0",


### PR DESCRIPTION
This removes the dependency on ecc-jsbn 0.0.1 which unfortunately depends on a Git version of jsbn. That fact broke our build today (since we don’t have Git on our build server).

The upgrade to ecc-jsbn 0.1.1 should hopefully not cause any problems for this package.

It was already already being used in earlier versions since the old version range (before 7c4fc623db) was `>=0.0.1 <1.0.0` which included `0.1.1` while `^0.0.1` does not.