### PR TITLE
Use Buffer.(from|alloc) instead of deprecated Buffer API

### DIFF
--- a/bin/sshpk-verify
+++ b/bin/sshpk-verify
@@ -7,6 +7,7 @@ var dashdash = require('dashdash');
 var sshpk = require('../lib/index');
 var fs = require('fs');
 var path = require('path');
+var Buffer = require('safer-buffer').Buffer;
 
 var options = [
 	{
@@ -93,7 +94,7 @@ if (require.main === module) {
 	}
 
 	var fmt = opts.format || 'asn1';
-	var sigData = new Buffer(opts.signature, 'base64');
+	var sigData = Buffer.from(opts.signature, 'base64');
 
 	var sig;
 	try {

--- a/lib/algs.js
+++ b/lib/algs.js
@@ -1,5 +1,7 @@
 // Copyright 2015 Joyent, Inc.
 
+var Buffer = require('safer-buffer').Buffer;
+
 var algInfo = {
 	'dsa': {
 		parts: ['p', 'q', 'g', 'y'],
@@ -52,27 +54,27 @@ var curves = {
 	'nistp256': {
 		size: 256,
 		pkcs8oid: '1.2.840.10045.3.1.7',
-		p: new Buffer(('00' +
+		p: Buffer.from(('00' +
 		    'ffffffff 00000001 00000000 00000000' +
 		    '00000000 ffffffff ffffffff ffffffff').
 		    replace(/ /g, ''), 'hex'),
-		a: new Buffer(('00' +
+		a: Buffer.from(('00' +
 		    'FFFFFFFF 00000001 00000000 00000000' +
 		    '00000000 FFFFFFFF FFFFFFFF FFFFFFFC').
 		    replace(/ /g, ''), 'hex'),
-		b: new Buffer((
+		b: Buffer.from((
 		    '5ac635d8 aa3a93e7 b3ebbd55 769886bc' +
 		    '651d06b0 cc53b0f6 3bce3c3e 27d2604b').
 		    replace(/ /g, ''), 'hex'),
-		s: new Buffer(('00' +
+		s: Buffer.from(('00' +
 		    'c49d3608 86e70493 6a6678e1 139d26b7' +
 		    '819f7e90').
 		    replace(/ /g, ''), 'hex'),
-		n: new Buffer(('00' +
+		n: Buffer.from(('00' +
 		    'ffffffff 00000000 ffffffff ffffffff' +
 		    'bce6faad a7179e84 f3b9cac2 fc632551').
 		    replace(/ /g, ''), 'hex'),
-		G: new Buffer(('04' +
+		G: Buffer.from(('04' +
 		    '6b17d1f2 e12c4247 f8bce6e5 63a440f2' +
 		    '77037d81 2deb33a0 f4a13945 d898c296' +
 		    '4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16' +
@@ -82,31 +84,31 @@ var curves = {
 	'nistp384': {
 		size: 384,
 		pkcs8oid: '1.3.132.0.34',
-		p: new Buffer(('00' +
+		p: Buffer.from(('00' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff ffffffff fffffffe' +
 		    'ffffffff 00000000 00000000 ffffffff').
 		    replace(/ /g, ''), 'hex'),
-		a: new Buffer(('00' +
+		a: Buffer.from(('00' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE' +
 		    'FFFFFFFF 00000000 00000000 FFFFFFFC').
 		    replace(/ /g, ''), 'hex'),
-		b: new Buffer((
+		b: Buffer.from((
 		    'b3312fa7 e23ee7e4 988e056b e3f82d19' +
 		    '181d9c6e fe814112 0314088f 5013875a' +
 		    'c656398d 8a2ed19d 2a85c8ed d3ec2aef').
 		    replace(/ /g, ''), 'hex'),
-		s: new Buffer(('00' +
+		s: Buffer.from(('00' +
 		    'a335926a a319a27a 1d00896a 6773a482' +
 		    '7acdac73').
 		    replace(/ /g, ''), 'hex'),
-		n: new Buffer(('00' +
+		n: Buffer.from(('00' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff c7634d81 f4372ddf' +
 		    '581a0db2 48b0a77a ecec196a ccc52973').
 		    replace(/ /g, ''), 'hex'),
-		G: new Buffer(('04' +
+		G: Buffer.from(('04' +
 		    'aa87ca22 be8b0537 8eb1c71e f320ad74' +
 		    '6e1d3b62 8ba79b98 59f741e0 82542a38' +
 		    '5502f25d bf55296c 3a545e38 72760ab7' +
@@ -118,34 +120,34 @@ var curves = {
 	'nistp521': {
 		size: 521,
 		pkcs8oid: '1.3.132.0.35',
-		p: new Buffer((
+		p: Buffer.from((
 		    '01ffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffff').replace(/ /g, ''), 'hex'),
-		a: new Buffer(('01FF' +
+		a: Buffer.from(('01FF' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF' +
 		    'FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFC').
 		    replace(/ /g, ''), 'hex'),
-		b: new Buffer(('51' +
+		b: Buffer.from(('51' +
 		    '953eb961 8e1c9a1f 929a21a0 b68540ee' +
 		    'a2da725b 99b315f3 b8b48991 8ef109e1' +
 		    '56193951 ec7e937b 1652c0bd 3bb1bf07' +
 		    '3573df88 3d2c34f1 ef451fd4 6b503f00').
 		    replace(/ /g, ''), 'hex'),
-		s: new Buffer(('00' +
+		s: Buffer.from(('00' +
 		    'd09e8800 291cb853 96cc6717 393284aa' +
 		    'a0da64ba').replace(/ /g, ''), 'hex'),
-		n: new Buffer(('01ff' +
+		n: Buffer.from(('01ff' +
 		    'ffffffff ffffffff ffffffff ffffffff' +
 		    'ffffffff ffffffff ffffffff fffffffa' +
 		    '51868783 bf2f966b 7fcc0148 f709a5d0' +
 		    '3bb5c9b8 899c47ae bb6fb71e 91386409').
 		    replace(/ /g, ''), 'hex'),
-		G: new Buffer(('04' +
+		G: Buffer.from(('04' +
 		    '00c6 858e06b7 0404e9cd 9e3ecb66 2395b442' +
 		         '9c648139 053fb521 f828af60 6b4d3dba' +
 		         'a14b5e77 efe75928 fe1dc127 a2ffa8de' +

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -3,6 +3,7 @@
 module.exports = Certificate;
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('./algs');
 var crypto = require('crypto');
 var Fingerprint = require('./fingerprint');
@@ -185,7 +186,7 @@ Certificate.createSelfSigned = function (subjectOrSubjects, key, options) {
 	assert.optionalBuffer(options.serial, 'options.serial');
 	var serial = options.serial;
 	if (serial === undefined)
-		serial = new Buffer('0000000000000001', 'hex');
+		serial = Buffer.from('0000000000000001', 'hex');
 
 	var purposes = options.purposes;
 	if (purposes === undefined)
@@ -283,7 +284,7 @@ Certificate.create =
 	assert.optionalBuffer(options.serial, 'options.serial');
 	var serial = options.serial;
 	if (serial === undefined)
-		serial = new Buffer('0000000000000001', 'hex');
+		serial = Buffer.from('0000000000000001', 'hex');
 
 	var purposes = options.purposes;
 	if (purposes === undefined)

--- a/lib/dhe.js
+++ b/lib/dhe.js
@@ -8,6 +8,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var crypto = require('crypto');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('./algs');
 var utils = require('./utils');
 var nacl;
@@ -189,7 +190,7 @@ DiffieHellman.prototype.computeSecret = function (otherpk) {
 		var secret = nacl.box.before(new Uint8Array(pub),
 		    new Uint8Array(priv));
 
-		return (new Buffer(secret));
+		return (Buffer.from(secret));
 	}
 
 	throw (new Error('Invalid algorithm: ' + this._algo));
@@ -218,7 +219,7 @@ DiffieHellman.prototype.generateKey = function () {
 			this._dh.generateKeys();
 
 			parts.push({name: 'curve',
-			    data: new Buffer(this._curve)});
+			    data: Buffer.from(this._curve)});
 			parts.push({name: 'Q', data: this._dh.getPublicKey()});
 			parts.push({name: 'd', data: this._dh.getPrivateKey()});
 			this._key = new PrivateKey({
@@ -236,14 +237,14 @@ DiffieHellman.prototype.generateKey = function () {
 			priv = r.mod(n1).add(jsbn.ONE);
 			pub = this._ecParams.getG().multiply(priv);
 
-			priv = new Buffer(priv.toByteArray());
-			pub = new Buffer(this._ecParams.getCurve().
+			priv = Buffer.from(priv.toByteArray());
+			pub = Buffer.from(this._ecParams.getCurve().
 			    encodePointHex(pub), 'hex');
 
 			this._priv = new ECPrivate(this._ecParams, priv);
 
 			parts.push({name: 'curve',
-			    data: new Buffer(this._curve)});
+			    data: Buffer.from(this._curve)});
 			parts.push({name: 'Q', data: pub});
 			parts.push({name: 'd', data: priv});
 
@@ -258,8 +259,8 @@ DiffieHellman.prototype.generateKey = function () {
 
 	} else if (this._algo === 'curve25519') {
 		var pair = nacl.box.keyPair();
-		priv = new Buffer(pair.secretKey);
-		pub = new Buffer(pair.publicKey);
+		priv = Buffer.from(pair.secretKey);
+		pub = Buffer.from(pair.publicKey);
 		priv = Buffer.concat([priv, pub]);
 		assert.strictEqual(priv.length, 64);
 		assert.strictEqual(pub.length, 32);
@@ -316,7 +317,7 @@ function ECPrivate(params, buffer) {
 ECPrivate.prototype.deriveSharedSecret = function (pubKey) {
 	assert.ok(pubKey instanceof ECPublic);
 	var S = pubKey._pub.multiply(this._priv);
-	return (new Buffer(S.getX().toBigInteger().toByteArray()));
+	return (Buffer.from(S.getX().toBigInteger().toByteArray()));
 };
 
 function generateED25519() {
@@ -324,8 +325,8 @@ function generateED25519() {
 		nacl = require('tweetnacl');
 
 	var pair = nacl.sign.keyPair();
-	var priv = new Buffer(pair.secretKey);
-	var pub = new Buffer(pair.publicKey);
+	var priv = Buffer.from(pair.secretKey);
+	var pub = Buffer.from(pair.publicKey);
 	assert.strictEqual(priv.length, 64);
 	assert.strictEqual(pub.length, 32);
 
@@ -362,7 +363,7 @@ function generateECDSA(curve) {
 		dh.generateKeys();
 
 		parts.push({name: 'curve',
-		    data: new Buffer(curve)});
+		    data: Buffer.from(curve)});
 		parts.push({name: 'Q', data: dh.getPublicKey()});
 		parts.push({name: 'd', data: dh.getPrivateKey()});
 
@@ -395,11 +396,11 @@ function generateECDSA(curve) {
 		var priv = c.mod(n1).add(jsbn.ONE);
 		var pub = ecParams.getG().multiply(priv);
 
-		priv = new Buffer(priv.toByteArray());
-		pub = new Buffer(ecParams.getCurve().
+		priv = Buffer.from(priv.toByteArray());
+		pub = Buffer.from(ecParams.getCurve().
 		    encodePointHex(pub), 'hex');
 
-		parts.push({name: 'curve', data: new Buffer(curve)});
+		parts.push({name: 'curve', data: Buffer.from(curve)});
 		parts.push({name: 'Q', data: pub});
 		parts.push({name: 'd', data: priv});
 

--- a/lib/ed-compat.js
+++ b/lib/ed-compat.js
@@ -9,6 +9,7 @@ var nacl;
 var stream = require('stream');
 var util = require('util');
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var Signature = require('./signature');
 
 function Verifier(key, hashAlgo) {
@@ -33,7 +34,7 @@ Verifier.prototype._write = function (chunk, enc, cb) {
 
 Verifier.prototype.update = function (chunk) {
 	if (typeof (chunk) === 'string')
-		chunk = new Buffer(chunk, 'binary');
+		chunk = Buffer.from(chunk, 'binary');
 	this.chunks.push(chunk);
 };
 
@@ -45,7 +46,7 @@ Verifier.prototype.verify = function (signature, fmt) {
 		sig = signature.toBuffer('raw');
 
 	} else if (typeof (signature) === 'string') {
-		sig = new Buffer(signature, 'base64');
+		sig = Buffer.from(signature, 'base64');
 
 	} else if (Signature.isSignature(signature, [1, 0])) {
 		throw (new Error('signature was created by too old ' +
@@ -81,7 +82,7 @@ Signer.prototype._write = function (chunk, enc, cb) {
 
 Signer.prototype.update = function (chunk) {
 	if (typeof (chunk) === 'string')
-		chunk = new Buffer(chunk, 'binary');
+		chunk = Buffer.from(chunk, 'binary');
 	this.chunks.push(chunk);
 };
 
@@ -90,7 +91,7 @@ Signer.prototype.sign = function () {
 	    new Uint8Array(Buffer.concat(this.chunks)),
 	    new Uint8Array(Buffer.concat([
 		this.key.part.k.data, this.key.part.A.data])));
-	var sigBuf = new Buffer(sig);
+	var sigBuf = Buffer.from(sig);
 	var sigObj = Signature.parse(sigBuf, 'ed25519', 'raw');
 	sigObj.hashAlgorithm = 'sha512';
 	return (sigObj);

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -3,6 +3,7 @@
 module.exports = Fingerprint;
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('./algs');
 var crypto = require('crypto');
 var errs = require('./errors');
@@ -90,7 +91,7 @@ Fingerprint.parse = function (fp, options) {
 		if (!base64RE.test(parts[1]))
 			throw (new FingerprintFormatError(fp));
 		try {
-			hash = new Buffer(parts[1], 'base64');
+			hash = Buffer.from(parts[1], 'base64');
 		} catch (e) {
 			throw (new FingerprintFormatError(fp));
 		}
@@ -104,7 +105,7 @@ Fingerprint.parse = function (fp, options) {
 		if (!md5RE.test(parts))
 			throw (new FingerprintFormatError(fp));
 		try {
-			hash = new Buffer(parts, 'hex');
+			hash = Buffer.from(parts, 'hex');
 		} catch (e) {
 			throw (new FingerprintFormatError(fp));
 		}

--- a/lib/formats/auto.js
+++ b/lib/formats/auto.js
@@ -6,6 +6,7 @@ module.exports = {
 };
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var utils = require('../utils');
 var Key = require('../key');
 var PrivateKey = require('../private-key');
@@ -27,7 +28,7 @@ function read(buf, options) {
 			return (ssh.read(buf, options));
 		if (findDNSSECHeader(buf))
 			return (dnssec.read(buf, options));
-		buf = new Buffer(buf, 'binary');
+		buf = Buffer.from(buf, 'binary');
 	} else {
 		assert.buffer(buf);
 		if (findPEMHeader(buf))

--- a/lib/formats/dnssec.js
+++ b/lib/formats/dnssec.js
@@ -6,6 +6,7 @@ module.exports = {
 };
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var Key = require('../key');
 var PrivateKey = require('../private-key');
 var utils = require('../utils');
@@ -66,7 +67,7 @@ function readRFC3110(keyString) {
 	if (!supportedAlgosById[algorithm])
 		throw (new Error('Unsupported algorithm: ' + algorithm));
 	var base64key = elems.slice(6, elems.length).join();
-	var keyBuffer = new Buffer(base64key, 'base64');
+	var keyBuffer = Buffer.from(base64key, 'base64');
 	if (supportedAlgosById[algorithm].match(/^RSA-/)) {
 		// join the rest of the body into a single base64-blob
 		var publicExponentLen = keyBuffer.readUInt8(0);
@@ -101,7 +102,7 @@ function readRFC3110(keyString) {
 			curve: curve,
 			size: size,
 			parts: [
-				{name: 'curve', data: new Buffer(curve) },
+				{name: 'curve', data: Buffer.from(curve) },
 				{name: 'Q', data: utils.ecNormalize(keyBuffer) }
 			]
 		};
@@ -112,7 +113,7 @@ function readRFC3110(keyString) {
 }
 
 function elementToBuf(e) {
-	return (new Buffer(e.split(' ')[1], 'base64'));
+	return (Buffer.from(e.split(' ')[1], 'base64'));
 }
 
 function readDNSSECRSAPrivateKey(elements) {
@@ -161,7 +162,7 @@ function readDNSSECPrivateKey(alg, elements) {
 	}
 	if (supportedAlgosById[alg] === 'ECDSA-P384-SHA384' ||
 	    supportedAlgosById[alg] === 'ECDSA-P256-SHA256') {
-		var d = new Buffer(elements[0].split(' ')[1], 'base64');
+		var d = Buffer.from(elements[0].split(' ')[1], 'base64');
 		var curve = 'nistp384';
 		var size = 384;
 		if (supportedAlgosById[alg] === 'ECDSA-P256-SHA256') {
@@ -176,7 +177,7 @@ function readDNSSECPrivateKey(alg, elements) {
 			curve: curve,
 			size: size,
 			parts: [
-				{name: 'curve', data: new Buffer(curve) },
+				{name: 'curve', data: Buffer.from(curve) },
 				{name: 'd', data: d },
 				{name: 'Q', data: Q }
 			]
@@ -237,7 +238,7 @@ function writeRSA(key, options) {
 	out += 'Created: ' + dnssecTimestamp(timestamp) + '\n';
 	out += 'Publish: ' + dnssecTimestamp(timestamp) + '\n';
 	out += 'Activate: ' + dnssecTimestamp(timestamp) + '\n';
-	return (new Buffer(out, 'ascii'));
+	return (Buffer.from(out, 'ascii'));
 }
 
 function writeECDSA(key, options) {
@@ -260,7 +261,7 @@ function writeECDSA(key, options) {
 	out += 'Publish: ' + dnssecTimestamp(timestamp) + '\n';
 	out += 'Activate: ' + dnssecTimestamp(timestamp) + '\n';
 
-	return (new Buffer(out, 'ascii'));
+	return (Buffer.from(out, 'ascii'));
 }
 
 function write(key, options) {

--- a/lib/formats/openssh-cert.js
+++ b/lib/formats/openssh-cert.js
@@ -15,6 +15,7 @@ module.exports = {
 var assert = require('assert-plus');
 var SSHBuffer = require('../ssh-buffer');
 var crypto = require('crypto');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var Key = require('../key');
 var PrivateKey = require('../private-key');
@@ -50,7 +51,7 @@ function read(buf, options) {
 	var algo = parts[0];
 	var data = parts[1];
 
-	data = new Buffer(data, 'base64');
+	data = Buffer.from(data, 'base64');
 	return (fromBuffer(data, algo));
 }
 
@@ -164,7 +165,7 @@ function dateToInt64(date) {
 	var i = Math.round(date.getTime() / 1000);
 	var upper = Math.floor(i / 4294967296);
 	var lower = Math.floor(i % 4294967296);
-	var buf = new Buffer(8);
+	var buf = Buffer.alloc(8);
 	buf.writeUInt32BE(upper, 0);
 	buf.writeUInt32BE(lower, 4);
 	return (buf);
@@ -278,15 +279,15 @@ function toBuffer(cert, noSig) {
 	buf.writeInt64(dateToInt64(cert.validUntil));
 
 	if (sig.critical === undefined)
-		sig.critical = new Buffer(0);
+		sig.critical = Buffer.alloc(0);
 	buf.writeBuffer(sig.critical);
 
 	if (sig.exts === undefined)
-		sig.exts = new Buffer(0);
+		sig.exts = Buffer.alloc(0);
 	buf.writeBuffer(sig.exts);
 
 	/* reserved */
-	buf.writeBuffer(new Buffer(0));
+	buf.writeBuffer(Buffer.alloc(0));
 
 	sub = rfc4253.write(cert.issuerKey);
 	buf.writeBuffer(sub);

--- a/lib/formats/pem.js
+++ b/lib/formats/pem.js
@@ -8,6 +8,7 @@ module.exports = {
 var assert = require('assert-plus');
 var asn1 = require('asn1');
 var crypto = require('crypto');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var Key = require('../key');
@@ -67,7 +68,7 @@ function read(buf, options, forceType) {
 		var parts = headers['proc-type'].split(',');
 		if (parts[0] === '4' && parts[1] === 'ENCRYPTED') {
 			if (typeof (options.passphrase) === 'string') {
-				options.passphrase = new Buffer(
+				options.passphrase = Buffer.from(
 				    options.passphrase, 'utf-8');
 			}
 			if (!Buffer.isBuffer(options.passphrase)) {
@@ -77,7 +78,7 @@ function read(buf, options, forceType) {
 				parts = headers['dek-info'].split(',');
 				assert.ok(parts.length === 2);
 				cipher = parts[0].toLowerCase();
-				iv = new Buffer(parts[1], 'hex');
+				iv = Buffer.from(parts[1], 'hex');
 				key = utils.opensslKeyDeriv(cipher, iv,
 				    options.passphrase, 1).key;
 			}
@@ -86,7 +87,7 @@ function read(buf, options, forceType) {
 
 	/* Chop off the first and last lines */
 	lines = lines.slice(0, -1).join('');
-	buf = new Buffer(lines, 'base64');
+	buf = Buffer.from(lines, 'base64');
 
 	if (cipher && key && iv) {
 		var cipherStream = crypto.createDecipheriv(cipher, key, iv);
@@ -174,7 +175,7 @@ function write(key, options, type) {
 	var tmp = der.buffer.toString('base64');
 	var len = tmp.length + (tmp.length / 64) +
 	    18 + 16 + header.length*2 + 10;
-	var buf = new Buffer(len);
+	var buf = Buffer.alloc(len);
 	var o = 0;
 	o += buf.write('-----BEGIN ' + header + '-----\n', o);
 	for (var i = 0; i < tmp.length; ) {

--- a/lib/formats/pkcs1.js
+++ b/lib/formats/pkcs1.js
@@ -9,6 +9,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 
@@ -209,7 +210,7 @@ function readPkcs1ECDSAPublic(der) {
 	var key = {
 		type: 'ecdsa',
 		parts: [
-			{ name: 'curve', data: new Buffer(curve) },
+			{ name: 'curve', data: Buffer.from(curve) },
 			{ name: 'Q', data: Q }
 		]
 	};
@@ -235,7 +236,7 @@ function readPkcs1ECDSAPrivate(der) {
 	var key = {
 		type: 'ecdsa',
 		parts: [
-			{ name: 'curve', data: new Buffer(curve) },
+			{ name: 'curve', data: Buffer.from(curve) },
 			{ name: 'Q', data: Q },
 			{ name: 'd', data: d }
 		]
@@ -285,8 +286,7 @@ function writePkcs1RSAPublic(der, key) {
 }
 
 function writePkcs1RSAPrivate(der, key) {
-	var ver = new Buffer(1);
-	ver[0] = 0;
+	var ver = Buffer.from([0]);
 	der.writeBuffer(ver, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.n.data, asn1.Ber.Integer);
@@ -302,8 +302,7 @@ function writePkcs1RSAPrivate(der, key) {
 }
 
 function writePkcs1DSAPrivate(der, key) {
-	var ver = new Buffer(1);
-	ver[0] = 0;
+	var ver = Buffer.from([0]);
 	der.writeBuffer(ver, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.p.data, asn1.Ber.Integer);
@@ -336,8 +335,7 @@ function writePkcs1ECDSAPublic(der, key) {
 }
 
 function writePkcs1ECDSAPrivate(der, key) {
-	var ver = new Buffer(1);
-	ver[0] = 1;
+	var ver = Buffer.from([1]);
 	der.writeBuffer(ver, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.d.data, asn1.Ber.OctetString);
@@ -356,8 +354,7 @@ function writePkcs1ECDSAPrivate(der, key) {
 }
 
 function writePkcs1EdDSAPrivate(der, key) {
-	var ver = new Buffer(1);
-	ver[0] = 1;
+	var ver = Buffer.from([1]);
 	der.writeBuffer(ver, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.k.data, asn1.Ber.OctetString);

--- a/lib/formats/pkcs8.js
+++ b/lib/formats/pkcs8.js
@@ -12,6 +12,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var Key = require('../key');
@@ -307,7 +308,7 @@ function readPkcs8ECDSAPrivate(der) {
 	var key = {
 		type: 'ecdsa',
 		parts: [
-			{ name: 'curve', data: new Buffer(curveName) },
+			{ name: 'curve', data: Buffer.from(curveName) },
 			{ name: 'Q', data: Q },
 			{ name: 'd', data: d }
 		]
@@ -326,7 +327,7 @@ function readPkcs8ECDSAPublic(der) {
 	var key = {
 		type: 'ecdsa',
 		parts: [
-			{ name: 'curve', data: new Buffer(curveName) },
+			{ name: 'curve', data: Buffer.from(curveName) },
 			{ name: 'Q', data: Q }
 		]
 	};
@@ -415,8 +416,7 @@ function writePkcs8(der, key) {
 	der.startSequence();
 
 	if (PrivateKey.isPrivateKey(key)) {
-		var sillyInt = new Buffer(1);
-		sillyInt[0] = 0x0;
+		var sillyInt = Buffer.from([0]);
 		der.writeBuffer(sillyInt, asn1.Ber.Integer);
 	}
 
@@ -464,8 +464,7 @@ function writePkcs8RSAPrivate(key, der) {
 	der.startSequence(asn1.Ber.OctetString);
 	der.startSequence();
 
-	var version = new Buffer(1);
-	version[0] = 0;
+	var version = Buffer.from([0]);
 	der.writeBuffer(version, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.n.data, asn1.Ber.Integer);
@@ -536,8 +535,7 @@ function writeECDSACurve(key, der) {
 		// ECParameters sequence
 		der.startSequence();
 
-		var version = new Buffer(1);
-		version.writeUInt8(1, 0);
+		var version = Buffer.from([1]);
 		der.writeBuffer(version, asn1.Ber.Integer);
 
 		// FieldID sequence
@@ -560,8 +558,7 @@ function writeECDSACurve(key, der) {
 		der.writeBuffer(curve.n, asn1.Ber.Integer);
 		var h = curve.h;
 		if (!h) {
-			h = new Buffer(1);
-			h[0] = 1;
+			h = Buffer.from([1]);
 		}
 		der.writeBuffer(h, asn1.Ber.Integer);
 
@@ -585,8 +582,7 @@ function writePkcs8ECDSAPrivate(key, der) {
 	der.startSequence(asn1.Ber.OctetString);
 	der.startSequence();
 
-	var version = new Buffer(1);
-	version[0] = 1;
+	var version = Buffer.from([1]);
 	der.writeBuffer(version, asn1.Ber.Integer);
 
 	der.writeBuffer(key.part.d.data, asn1.Ber.OctetString);

--- a/lib/formats/rfc4253.js
+++ b/lib/formats/rfc4253.js
@@ -14,6 +14,7 @@ module.exports = {
 };
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var Key = require('../key');
@@ -54,7 +55,7 @@ function keyTypeToAlg(key) {
 
 function read(partial, type, buf, options) {
 	if (typeof (buf) === 'string')
-		buf = new Buffer(buf);
+		buf = Buffer.from(buf);
 	assert.buffer(buf, 'buf');
 
 	var key = {};

--- a/lib/formats/ssh-private.js
+++ b/lib/formats/ssh-private.js
@@ -8,6 +8,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var crypto = require('crypto');
@@ -70,7 +71,7 @@ function readSSHPrivate(type, buf, options) {
 		}
 
 		if (typeof (options.passphrase) === 'string') {
-			options.passphrase = new Buffer(options.passphrase,
+			options.passphrase = Buffer.from(options.passphrase,
 			    'utf-8');
 		}
 		if (!Buffer.isBuffer(options.passphrase)) {
@@ -88,7 +89,7 @@ function readSSHPrivate(type, buf, options) {
 			throw (new Error('bcrypt_pbkdf function returned ' +
 			    'failure, parameters invalid'));
 		}
-		out = new Buffer(out);
+		out = Buffer.from(out);
 		var ckey = out.slice(0, cinf.keySize);
 		var iv = out.slice(cinf.keySize, cinf.keySize + cinf.blockSize);
 		var cipherStream = crypto.createDecipheriv(cinf.opensslName,
@@ -142,13 +143,13 @@ function write(key, options) {
 
 	var cipher = 'none';
 	var kdf = 'none';
-	var kdfopts = new Buffer(0);
+	var kdfopts = Buffer.alloc(0);
 	var cinf = { blockSize: 8 };
 	var passphrase;
 	if (options !== undefined) {
 		passphrase = options.passphrase;
 		if (typeof (passphrase) === 'string')
-			passphrase = new Buffer(passphrase, 'utf-8');
+			passphrase = Buffer.from(passphrase, 'utf-8');
 		if (passphrase !== undefined) {
 			assert.buffer(passphrase, 'options.passphrase');
 			assert.optionalString(options.cipher, 'options.cipher');
@@ -199,7 +200,7 @@ function write(key, options) {
 			throw (new Error('bcrypt_pbkdf function returned ' +
 			    'failure, parameters invalid'));
 		}
-		out = new Buffer(out);
+		out = Buffer.from(out);
 		var ckey = out.slice(0, cinf.keySize);
 		var iv = out.slice(cinf.keySize, cinf.keySize + cinf.blockSize);
 
@@ -244,7 +245,7 @@ function write(key, options) {
 	var tmp = buf.toString('base64');
 	var len = tmp.length + (tmp.length / 70) +
 	    18 + 16 + header.length*2 + 10;
-	buf = new Buffer(len);
+	buf = Buffer.alloc(len);
 	var o = 0;
 	o += buf.write('-----BEGIN ' + header + '-----\n', o);
 	for (var i = 0; i < tmp.length; ) {

--- a/lib/formats/ssh.js
+++ b/lib/formats/ssh.js
@@ -6,6 +6,7 @@ module.exports = {
 };
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var rfc4253 = require('./rfc4253');
 var utils = require('../utils');
 var Key = require('../key');
@@ -31,7 +32,7 @@ function read(buf, options) {
 	assert.ok(m, 'key must match regex');
 
 	var type = rfc4253.algToKeyType(m[1]);
-	var kbuf = new Buffer(m[2], 'base64');
+	var kbuf = Buffer.from(m[2], 'base64');
 
 	/*
 	 * This is a bit tricky. If we managed to parse the key and locate the
@@ -50,7 +51,7 @@ function read(buf, options) {
 		} catch (e) {
 			m = trimmed.match(SSHKEY_RE2);
 			assert.ok(m, 'key must match regex');
-			kbuf = new Buffer(m[2], 'base64');
+			kbuf = Buffer.from(m[2], 'base64');
 			key = rfc4253.readInternal(ret, 'public', kbuf);
 		}
 	} else {
@@ -110,5 +111,5 @@ function write(key, options) {
 	if (key.comment)
 		parts.push(key.comment);
 
-	return (new Buffer(parts.join(' ')));
+	return (Buffer.from(parts.join(' ')));
 }

--- a/lib/formats/x509-pem.js
+++ b/lib/formats/x509-pem.js
@@ -11,6 +11,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var Key = require('../key');
@@ -48,7 +49,7 @@ function read(buf, options) {
 
 	/* Chop off the first and last lines */
 	lines = lines.slice(0, -1).join('');
-	buf = new Buffer(lines, 'base64');
+	buf = Buffer.from(lines, 'base64');
 
 	return (x509.read(buf, options));
 }
@@ -60,7 +61,7 @@ function write(cert, options) {
 	var tmp = dbuf.toString('base64');
 	var len = tmp.length + (tmp.length / 64) +
 	    18 + 16 + header.length*2 + 10;
-	var buf = new Buffer(len);
+	var buf = Buffer.alloc(len);
 	var o = 0;
 	o += buf.write('-----BEGIN ' + header + '-----\n', o);
 	for (var i = 0; i < tmp.length; ) {

--- a/lib/formats/x509.js
+++ b/lib/formats/x509.js
@@ -10,6 +10,7 @@ module.exports = {
 
 var assert = require('assert-plus');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('../algs');
 var utils = require('../utils');
 var Key = require('../key');
@@ -89,7 +90,7 @@ var EXTS = {
 
 function read(buf, options) {
 	if (typeof (buf) === 'string') {
-		buf = new Buffer(buf, 'binary');
+		buf = Buffer.from(buf, 'binary');
 	}
 	assert.buffer(buf, 'buf');
 
@@ -500,7 +501,7 @@ function write(cert, options) {
 	der.endSequence();
 
 	var sigData = sig.signature.toBuffer('asn1');
-	var data = new Buffer(sigData.length + 1);
+	var data = Buffer.alloc(sigData.length + 1);
 	data[0] = 0;
 	sigData.copy(data, 1);
 	der.writeBuffer(data, asn1.Ber.BitString);
@@ -710,8 +711,7 @@ function writeBitField(setBits, bitIndex) {
 	var bitLen = bitIndex.length;
 	var blen = Math.ceil(bitLen / 8);
 	var unused = blen * 8 - bitLen;
-	var bits = new Buffer(1 + blen);
-	bits.fill(0);
+	var bits = Buffer.alloc(1 + blen); // zero-filled
 	bits[0] = unused;
 	for (var i = 0; i < bitLen; ++i) {
 		var byteN = 1 + Math.floor(i / 8);

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -11,6 +11,7 @@ var errs = require('./errors');
 var util = require('util');
 var utils = require('./utils');
 var asn1 = require('asn1');
+var Buffer = require('safer-buffer').Buffer;
 
 /*JSSTYLED*/
 var DNS_NAME_RE = /^([*]|[a-z0-9][a-z0-9\-]{0,62})(?:\.([*]|[a-z0-9][a-z0-9\-]{0,62}))*$/i;
@@ -143,7 +144,7 @@ Identity.prototype.toAsn1 = function (der, tag) {
 		 */
 		if (c.asn1type === asn1.Ber.Utf8String ||
 		    c.value.match(NOT_IA5)) {
-			var v = new Buffer(c.value, 'utf8');
+			var v = Buffer.from(c.value, 'utf8');
 			der.writeBuffer(v, asn1.Ber.Utf8String);
 
 		} else if (c.asn1type === asn1.Ber.IA5String ||

--- a/lib/private-key.js
+++ b/lib/private-key.js
@@ -3,6 +3,7 @@
 module.exports = PrivateKey;
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('./algs');
 var crypto = require('crypto');
 var Fingerprint = require('./fingerprint');
@@ -97,7 +98,7 @@ PrivateKey.prototype.derive = function (newType) {
 			priv = priv.slice(1);
 
 		pair = nacl.box.keyPair.fromSecretKey(new Uint8Array(priv));
-		pub = new Buffer(pair.publicKey);
+		pub = Buffer.from(pair.publicKey);
 
 		return (new PrivateKey({
 			type: 'curve25519',
@@ -115,7 +116,7 @@ PrivateKey.prototype.derive = function (newType) {
 			priv = priv.slice(1);
 
 		pair = nacl.sign.keyPair.fromSeed(new Uint8Array(priv));
-		pub = new Buffer(pair.publicKey);
+		pub = Buffer.from(pair.publicKey);
 
 		return (new PrivateKey({
 			type: 'ed25519',
@@ -166,7 +167,7 @@ PrivateKey.prototype.createSign = function (hashAlgo) {
 	v.sign = function () {
 		var sig = oldSign(key);
 		if (typeof (sig) === 'string')
-			sig = new Buffer(sig, 'binary');
+			sig = Buffer.from(sig, 'binary');
 		sig = Signature.parse(sig, type, 'asn1');
 		sig.hashAlgorithm = hashAlgo;
 		sig.curve = curve;

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -3,6 +3,7 @@
 module.exports = Signature;
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var algs = require('./algs');
 var crypto = require('crypto');
 var errs = require('./errors');
@@ -141,7 +142,7 @@ Signature.prototype.toString = function (format) {
 
 Signature.parse = function (data, type, format) {
 	if (typeof (data) === 'string')
-		data = new Buffer(data, 'base64');
+		data = Buffer.from(data, 'base64');
 	assert.buffer(data, 'data');
 	assert.string(format, 'format');
 	assert.string(type, 'type');

--- a/lib/ssh-buffer.js
+++ b/lib/ssh-buffer.js
@@ -3,6 +3,7 @@
 module.exports = SSHBuffer;
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 
 function SSHBuffer(opts) {
 	assert.object(opts, 'options');
@@ -10,7 +11,7 @@ function SSHBuffer(opts) {
 		assert.buffer(opts.buffer, 'options.buffer');
 
 	this._size = opts.buffer ? opts.buffer.length : 1024;
-	this._buffer = opts.buffer || (new Buffer(this._size));
+	this._buffer = opts.buffer || Buffer.alloc(this._size);
 	this._offset = 0;
 }
 
@@ -32,7 +33,7 @@ SSHBuffer.prototype.skip = function (n) {
 
 SSHBuffer.prototype.expand = function () {
 	this._size *= 2;
-	var buf = new Buffer(this._size);
+	var buf = Buffer.alloc(this._size);
 	this._buffer.copy(buf, 0);
 	this._buffer = buf;
 };
@@ -96,7 +97,7 @@ SSHBuffer.prototype.writeBuffer = function (buf) {
 };
 
 SSHBuffer.prototype.writeString = function (str) {
-	this.writeBuffer(new Buffer(str, 'utf8'));
+	this.writeBuffer(Buffer.from(str, 'utf8'));
 };
 
 SSHBuffer.prototype.writeCString = function (str) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,7 @@ module.exports = {
 };
 
 var assert = require('assert-plus');
+var Buffer = require('safer-buffer').Buffer;
 var PrivateKey = require('./private-key');
 var Key = require('./key');
 var crypto = require('crypto');
@@ -101,7 +102,7 @@ function opensslKeyDeriv(cipher, salt, passphrase, count) {
 	salt = salt.slice(0, PKCS5_SALT_LEN);
 
 	var D, D_prev, bufs;
-	var material = new Buffer(0);
+	var material = Buffer.alloc(0);
 	while (material.length < clen.key + clen.iv) {
 		bufs = [];
 		if (D_prev)
@@ -185,7 +186,7 @@ function ecNormalize(buf, addZero) {
 		if (!addZero)
 			return (buf);
 	}
-	var b = new Buffer(buf.length + 1);
+	var b = Buffer.alloc(buf.length + 1);
 	b[0] = 0x0;
 	buf.copy(b, 1);
 	return (b);
@@ -203,7 +204,7 @@ function readBitString(der, tag) {
 function writeBitString(der, buf, tag) {
 	if (tag === undefined)
 		tag = asn1.Ber.BitString;
-	var b = new Buffer(buf.length + 1);
+	var b = Buffer.alloc(buf.length + 1);
 	b[0] = 0x00;
 	buf.copy(b, 1);
 	der.writeBuffer(b, tag);
@@ -214,7 +215,7 @@ function mpNormalize(buf) {
 	while (buf.length > 1 && buf[0] === 0x00 && (buf[1] & 0x80) === 0x00)
 		buf = buf.slice(1);
 	if ((buf[0] & 0x80) === 0x80) {
-		var b = new Buffer(buf.length + 1);
+		var b = Buffer.alloc(buf.length + 1);
 		b[0] = 0x00;
 		buf.copy(b, 1);
 		buf = b;
@@ -237,7 +238,7 @@ function zeroPadToLength(buf, len) {
 		buf = buf.slice(1);
 	}
 	while (buf.length < len) {
-		var b = new Buffer(buf.length + 1);
+		var b = Buffer.alloc(buf.length + 1);
 		b[0] = 0x00;
 		buf.copy(b, 1);
 		buf = b;
@@ -246,7 +247,7 @@ function zeroPadToLength(buf, len) {
 }
 
 function bigintToMpBuf(bigint) {
-	var buf = new Buffer(bigint.toByteArray());
+	var buf = Buffer.from(bigint.toByteArray());
 	buf = mpNormalize(buf);
 	return (buf);
 }
@@ -276,7 +277,7 @@ function calculateED25519Public(k) {
 		nacl = require('tweetnacl');
 
 	var kp = nacl.sign.keyPair.fromSeed(new Uint8Array(k));
-	return (new Buffer(kp.publicKey));
+	return (Buffer.from(kp.publicKey));
 }
 
 function calculateX25519Public(k) {
@@ -286,7 +287,7 @@ function calculateX25519Public(k) {
 		nacl = require('tweetnacl');
 
 	var kp = nacl.box.keyPair.fromSeed(new Uint8Array(k));
-	return (new Buffer(kp.publicKey));
+	return (Buffer.from(kp.publicKey));
 }
 
 function addRSAMissing(key) {
@@ -336,10 +337,10 @@ function publicFromPrivateECDSA(curveName, priv) {
 
 	var d = new jsbn(mpNormalize(priv));
 	var pub = G.multiply(d);
-	pub = new Buffer(curve.encodePointHex(pub), 'hex');
+	pub = Buffer.from(curve.encodePointHex(pub), 'hex');
 
 	var parts = [];
-	parts.push({name: 'curve', data: new Buffer(curveName)});
+	parts.push({name: 'curve', data: Buffer.from(curveName)});
 	parts.push({name: 'Q', data: pub});
 
 	var key = new Key({type: 'ecdsa', curve: curve, parts: parts});

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "asn1": "~0.2.3",
     "assert-plus": "^1.0.0",
     "dashdash": "^1.12.0",
-    "getpass": "^0.1.1"
+    "getpass": "^0.1.1",
+    "safer-buffer": "^2.0.2"
   },
   "optionalDependencies": {
     "jsbn": "~0.1.0",

--- a/test/dhe.js
+++ b/test/dhe.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var sinon = require('sinon');
+var Buffer = require('safer-buffer').Buffer;
 
 var ED_KEY, ED2_KEY, EC_KEY, EC2_KEY, ECOUT_KEY, DS_KEY, DS2_KEY, DSOUT_KEY;
 var C_KEY, C2_KEY;
@@ -108,7 +109,7 @@ test('ecdhe shared secret', function (t) {
 	var dh1 = EC_KEY.createDH();
 	var secret1 = dh1.computeSecret(EC2_KEY.toPublic());
 	t.ok(Buffer.isBuffer(secret1));
-	t.deepEqual(secret1, new Buffer(
+	t.deepEqual(secret1, Buffer.from(
 	    'UoKiio/gnWj4BdV41YvoHu9yhjynGBmphZ1JFbpk30o=', 'base64'));
 
 	var dh2 = EC2_KEY.createDH();

--- a/test/dhe_compat.js
+++ b/test/dhe_compat.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var sinon = require('sinon');
+var Buffer = require('safer-buffer').Buffer;
 
 /* No need to do these on an older node */
 if (crypto.createECDH === undefined)
@@ -57,7 +58,7 @@ test('ecdhe shared secret', function (t) {
 	var dh1 = new sshpk_dhe.DiffieHellman(EC_KEY);
 	var secret1 = dh1.computeSecret(EC2_KEY.toPublic());
 	t.ok(Buffer.isBuffer(secret1));
-	t.deepEqual(secret1, new Buffer(
+	t.deepEqual(secret1, Buffer.from(
 	    'UoKiio/gnWj4BdV41YvoHu9yhjynGBmphZ1JFbpk30o=', 'base64'));
 
 	var dh2 = new sshpk_dhe.DiffieHellman(EC2_KEY);

--- a/test/pem.js
+++ b/test/pem.js
@@ -3,6 +3,7 @@
 var test = require('tape').test;
 
 var sshpk = require('../lib/index');
+var Buffer = require('safer-buffer').Buffer;
 
 ///--- Globals
 var SSH_1024 = 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAvad19ePSDckmgmo6Unqmd8' +
@@ -173,7 +174,7 @@ var ECDSA_PEM = '-----BEGIN PUBLIC KEY-----\n' +
     '/aMP2QJ2bY6cTDbegg81Yo/PKMtYKkn1Tu+vD8ZjVBL8g2qjbMpc0yryIQ==\n' +
     '-----END PUBLIC KEY-----\n';
 
-var RFC_AUTO = new Buffer('AAAAC3NzaC1lZDI1NTE5AAAAIEi0pkfPe/+kbmnTSH0mfr0J' +
+var RFC_AUTO = Buffer.from('AAAAC3NzaC1lZDI1NTE5AAAAIEi0pkfPe/+kbmnTSH0mfr0J' +
     '4Fq7M7bshFAKB6uCyLDm', 'base64');
 
 ///--- Tests
@@ -259,7 +260,7 @@ test('256bit ecdsa as auto from string', function(t) {
 });
 
 test('256bit ecdsa as auto from buffer', function(t) {
-	var k = sshpk.parseKey(new Buffer('  ' + ECDSA_SSH), 'auto');
+	var k = sshpk.parseKey(Buffer.from('  ' + ECDSA_SSH), 'auto');
 	t.equal(k.toString('pem'), ECDSA_PEM);
 	t.end();
 });

--- a/test/ssh-buffer.js
+++ b/test/ssh-buffer.js
@@ -2,9 +2,10 @@
 
 var test = require('tape').test;
 var SSHBuffer = require('../lib/ssh-buffer');
+var Buffer = require('safer-buffer').Buffer;
 
 test('expands on write', function(t) {
-	var buf = new SSHBuffer({buffer: new Buffer(8)});
+	var buf = new SSHBuffer({buffer: Buffer.alloc(8)});
 	buf.writeCString('abc123');
 	buf.writeInt(42);
 	buf.writeString('hi there what is up');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,12 @@
 // Copyright 2011 Joyent, Inc.  All rights reserved.
 
 var test = require('tape').test;
+var Buffer = require('safer-buffer').Buffer;
 
 var utils = require('../lib/utils');
 
 test('bufferSplit single char', function(t) {
-	var b = new Buffer('abc 123 xyz ttt');
+	var b = Buffer.from('abc 123 xyz ttt');
 	var r = utils.bufferSplit(b, ' ');
 	t.equal(r.length, 4);
 	t.equal(r[0].toString(), 'abc');
@@ -15,7 +16,7 @@ test('bufferSplit single char', function(t) {
 });
 
 test('bufferSplit single char double sep', function(t) {
-	var b = new Buffer('abc 123 xyz   ttt');
+	var b = Buffer.from('abc 123 xyz   ttt');
 	var r = utils.bufferSplit(b, ' ');
 	t.equal(r.length, 6);
 	t.equal(r[0].toString(), 'abc');
@@ -26,7 +27,7 @@ test('bufferSplit single char double sep', function(t) {
 });
 
 test('bufferSplit multi char', function(t) {
-	var b = new Buffer('abc 123 xyz ttt  ');
+	var b = Buffer.from('abc 123 xyz ttt  ');
 	var r = utils.bufferSplit(b, '123');
 	t.equal(r.length, 2);
 	t.equal(r[0].toString(), 'abc ');


### PR DESCRIPTION
This also includes a dependnecy on a polyfill targeting older Node.js versions where Buffer.alloc() and Buffer.from() API is not implemented (Node.js < 4.5.0 and some 5.x versions).

This is mostly a line-to-line change, though in some cases, minor code simplification was done, e.g.
```js
var version = new Buffer(1);
version.writeUInt8(1, 0);
```
was transformed into
```js
var version = Buffer.from([1]);
```

Ref: https://github.com/nodejs/node/issues/19079
Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Ref: https://nodejs.org/api/buffer.html#buffer_class_buffer
Ref: https://github.com/ChALkeR/safer-buffer/blob/master/Porting-Buffer.md
Fixes: #45

Note that this does not completely solve the problem yet, for a complete solution, `asn1` (a dependency) should also receive this fix (see below for that one).

But fixing the API usage in this package is still required, and a significant portion of tests pass without ever hitting the deprecated Buffer API in `asn1` dependency.