### PR TITLE
Support PKCS#5 AES-256-CBC encrypted private keys

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,8 @@ function assertCompatible(obj, klass, needVer, name) {
 
 var CIPHER_LEN = {
 	'des-ede3-cbc': { key: 7, iv: 8 },
-	'aes-128-cbc': { key: 16, iv: 16 }
+	'aes-128-cbc': { key: 16, iv: 16 },
+	'aes-256-cbc': { key: 32, iv: 16 }
 };
 var PKCS5_SALT_LEN = 8;
 


### PR DESCRIPTION
Add support for parsing PKCS#5 private keys encrypted with AES-256-CBC. 
Previous to this fix only 128 bits keys were supported:

```bash
openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_keygen_pubexp:6553 -outform pem -out key.priv
openssl rsa -aes128 -in key.priv -passout pass:pass -out key128.priv.crypt
openssl rsa -aes256 -in key.priv -passout pass:pass -out key256.priv.crypt
```

```js
// this also worked ok before this patch:
sshpk.parsePrivateKey(fs.readFileSync('key128.priv.crypt'), 'pem', { passphrase : 'pass'})
// this not, but now is ok:
sshpk.parsePrivateKey(fs.readFileSync('key256.priv.crypt'), 'pem', { passphrase : 'pass'})  
```