### PR TITLE
allow for adding ssh extensions to certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,9 @@ Parameters
                                   `lifetime` will be ignored
    - `serial` -- optional Buffer, the serial number of the certificate
    - `purposes` -- optional Array of String, X.509 key usage restrictions
+   - `extensions` -- optional Array of String to defined openssh extensions
+                     permit-pty, permit-user-rc, permit-port-forwarding, 
+                     permit-agent-forwarding, permit-X11-forwarding
 
 ### `Certificate#subjects`
 

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -258,14 +258,26 @@ Certificate.createSelfSigned = function (subjectOrSubjects, key, options) {
 			    purposes.indexOf('encryption') === -1)
 				purposes.push('encryption');
 		}
-	}
+  }
+
+  var extensions = (options.extensions || []).map((ext) => {
+    return {
+      "critical": false,
+      "name": ext,
+      "format": "openssh"
+    }
+  })
+
+  var signatures = {}
+  if (extensions.length > 0)
+    signatures = { openssh: { exts: extensions }}
 
 	var cert = new Certificate({
 		subjects: subjects,
 		issuer: subjects[0],
 		subjectKey: key.toPublic(),
 		issuerKey: key.toPublic(),
-		signatures: {},
+		signatures: signatures,
 		serial: serial,
 		validFrom: validFrom,
 		validUntil: validUntil,
@@ -353,12 +365,24 @@ Certificate.create =
 			purposes.push('encryption');
 	}
 
-	var cert = new Certificate({
+  var extensions = (options.extensions || []).map((ext) => {
+    return {
+      "critical": false,
+      "name": ext,
+      "format": "openssh"
+    }
+  })
+
+  var signatures = {}
+  if (extensions.length > 0)
+    signatures = { openssh: { exts: extensions } }
+
+  var cert = new Certificate({
 		subjects: subjects,
 		issuer: issuer,
 		subjectKey: key,
 		issuerKey: issuerKey.toPublic(),
-		signatures: {},
+		signatures: signatures,
 		serial: serial,
 		validFrom: validFrom,
 		validUntil: validUntil,

--- a/lib/formats/openssh-cert.js
+++ b/lib/formats/openssh-cert.js
@@ -310,8 +310,11 @@ function toBuffer(cert, noSig) {
 	exts.forEach(function (ext) {
 		if (ext.critical === true)
 			return;
-		extbuf.writeString(ext.name);
-		extbuf.writeBuffer(ext.data);
+    extbuf.writeString(ext.name);
+    if ('data' in ext)
+      extbuf.writeBuffer(ext.data);
+    else
+      extbuf.writeString('');
 	});
 	buf.writeBuffer(extbuf.toBuffer());
 


### PR DESCRIPTION
With the support to getExtensions to show the extensions of ssh certificates there should also be support for creating those extensions as well. 

Hopefully someone can help clean this up. Example of how to create the extenions

```
var cert = sshpk.createCertificate(ids, userKey, host, signingKey, {
    lifetime: 300, // 5 minutes
    extensions: [
      'permit-X11-forwarding',
      'permit-agent-forwarding',
      'permit-port-forwarding',
      'permit-pty',
      'permit-user-rc'
    ]
  })
```